### PR TITLE
Export Contexts, add Serialization

### DIFF
--- a/Crypto/Hash/CryptoAPI.hs
+++ b/Crypto/Hash/CryptoAPI.hs
@@ -34,21 +34,21 @@ module Crypto.Hash.CryptoAPI
     , CTXTiger, CTXWhirlpool
     ) where
 
-import qualified Crypto.Hash.MD2 as MD2 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.MD4 as MD4 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.MD5 as MD5 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.SHA1 as SHA1 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.SHA224 as SHA224 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.SHA256 as SHA256 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.SHA384 as SHA384 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.SHA512 as SHA512 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.SHA512t as SHA512t (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.SHA3 as SHA3 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.RIPEMD160 as RIPEMD160 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.Tiger as Tiger (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.Skein256 as Skein256 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.Skein512 as Skein512 (Ctx(..), init, update, finalize)
-import qualified Crypto.Hash.Whirlpool as Whirlpool (Ctx(..), init, update, finalize)
+import qualified Crypto.Hash.MD2 as MD2 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.MD4 as MD4 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.MD5 as MD5 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.SHA1 as SHA1 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.SHA224 as SHA224 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.SHA256 as SHA256 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.SHA384 as SHA384 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.SHA512 as SHA512 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.SHA512t as SHA512t (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.SHA3 as SHA3 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.RIPEMD160 as RIPEMD160 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.Tiger as Tiger (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.Skein256 as Skein256 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.Skein512 as Skein512 (Ctx(..), init, update, finalize, hash, hashlazy)
+import qualified Crypto.Hash.Whirlpool as Whirlpool (Ctx(..), init, update, finalize, hash, hashlazy)
 
 import Control.Monad (liftM)
 import Data.ByteString (ByteString)
@@ -81,6 +81,8 @@ instance Hash CTXNAME NAME where \
    ; initialCtx      = CTXNAME MODULENAME.init        \
    ; updateCtx (CTXNAME ctx) = CTXNAME . MODULENAME.update ctx      \
    ; finalize (CTXNAME ctx) bs = NAME $ MODULENAME.finalize (MODULENAME.update ctx bs) \
+   ; hash' = NAME . MODULENAME.hash \
+   ; hash  = NAME . MODULENAME.hashlazy \
    }; \
 \
 instance Serialize NAME where \
@@ -105,6 +107,8 @@ instance Hash CTXNAME NAME where \
    ; initialCtx      = CTXNAME (MODULENAME.init ILEN) \
    ; updateCtx (CTXNAME ctx) = CTXNAME . MODULENAME.update ctx      \
    ; finalize (CTXNAME ctx) bs = NAME $ MODULENAME.finalize (MODULENAME.update ctx bs) \
+   ; hash' = NAME . MODULENAME.hash OUTPUTLEN \
+   ; hash  = NAME . MODULENAME.hashlazy OUTPUTLEN \
    }; \
 \
 instance Serialize NAME where \


### PR DESCRIPTION
In order to allow specialization of hash-based data structures to specific structures, we must export the contexts of the hash:

```
-- From Crypto.HMAC:
newtype MacKey c d = MacKey Data.ByteString.Internal.ByteString

-- Consider the application code:
data KeyDatabase = KDB { Map UserId (MacKey someContext SHA256) }
```

That `someContext` type should be able to be fully specified.
