### PR TITLE
Set appropriate crypto-api lower bound for 'hash' in 'Hash' class

### DIFF
--- a/cryptohash-cryptoapi.cabal
+++ b/cryptohash-cryptoapi.cabal
@@ -1,5 +1,5 @@
 Name:                cryptohash-cryptoapi
-Version:             0.1.0
+Version:             0.1.1
 Description:         Crypto-api interfaces for cryptohash
 License:             BSD3
 License-file:        LICENSE
@@ -17,7 +17,7 @@ Library
   Build-Depends:     base >= 4 && < 6
                    , bytestring
                    , cryptohash >= 0.8.0
-                   , crypto-api >= 0.5
+                   , crypto-api >= 0.11
                    , tagged >= 0.1
                    , cereal >= 0.2
   Exposed-modules:   Crypto.Hash.CryptoAPI


### PR DESCRIPTION
Related to your query on the last pull request, yes the lower bound has gone up as a result.
