### PR TITLE
Avoid identifiers with apostrophes in CPP macros

### DIFF
--- a/Crypto/Hash/CryptoAPI.hs
+++ b/Crypto/Hash/CryptoAPI.hs
@@ -75,16 +75,6 @@ newtype CTXNAME = CTXNAME MODULENAME.Ctx; \
 \
 data NAME = NAME !ByteString deriving (Eq,Ord,Show); \
 \
-instance Hash CTXNAME NAME where \
-   { outputLength    = Tagged (OUTPUTLEN * 8) \
-   ; blockLength     = Tagged (BLOCKLEN * 8)  \
-   ; initialCtx      = CTXNAME MODULENAME.init        \
-   ; updateCtx (CTXNAME ctx) = CTXNAME . MODULENAME.update ctx      \
-   ; finalize (CTXNAME ctx) bs = NAME $ MODULENAME.finalize (MODULENAME.update ctx bs) \
-   ; hash' = NAME . MODULENAME.hash \
-   ; hash  = NAME . MODULENAME.hashlazy \
-   }; \
-\
 instance Serialize NAME where \
    { get          = liftM NAME (getByteString OUTPUTLEN) \
    ; put (NAME d) = putByteString d \
@@ -93,7 +83,15 @@ instance Serialize NAME where \
 instance Serialize CTXNAME where \
   { get                              = liftM (CTXNAME . MODULENAME.Ctx) get \
   ; put (CTXNAME (MODULENAME.Ctx c)) = put c \
-  }
+  }; \
+\
+instance Hash CTXNAME NAME where \
+   { outputLength    = Tagged (OUTPUTLEN * 8) \
+   ; blockLength     = Tagged (BLOCKLEN * 8)  \
+   ; initialCtx      = CTXNAME MODULENAME.init        \
+   ; updateCtx (CTXNAME ctx) = CTXNAME . MODULENAME.update ctx      \
+   ; finalize (CTXNAME ctx) bs = NAME $ MODULENAME.finalize (MODULENAME.update ctx bs) \
+   ; hash  = NAME . MODULENAME.hashlazy
 
 #define DEFINE_TYPE_AND_INSTANCES_WITHLEN(CTXNAME, NAME, ILEN, MODULENAME, OUTPUTLEN, BLOCKLEN)    \
 \
@@ -101,35 +99,69 @@ newtype CTXNAME = CTXNAME MODULENAME.Ctx; \
 \
 data NAME = NAME !ByteString deriving (Eq,Ord,Show); \
 \
+instance Serialize NAME where \
+   { get          = liftM NAME (getByteString OUTPUTLEN) \
+   ; put (NAME d) = putByteString d \
+   }; \
+\
 instance Hash CTXNAME NAME where \
    { outputLength    = Tagged (OUTPUTLEN * 8) \
    ; blockLength     = Tagged (BLOCKLEN * 8)  \
    ; initialCtx      = CTXNAME (MODULENAME.init ILEN) \
    ; updateCtx (CTXNAME ctx) = CTXNAME . MODULENAME.update ctx      \
    ; finalize (CTXNAME ctx) bs = NAME $ MODULENAME.finalize (MODULENAME.update ctx bs) \
-   ; hash' = NAME . MODULENAME.hash OUTPUTLEN \
-   ; hash  = NAME . MODULENAME.hashlazy OUTPUTLEN \
-   }; \
-\
-instance Serialize NAME where \
-   { get          = liftM NAME (getByteString OUTPUTLEN) \
-   ; put (NAME d) = putByteString d \
-   }
+   ; hash  = NAME . MODULENAME.hashlazy OUTPUTLEN
+
 
 DEFINE_TYPE_AND_INSTANCES_SIMPLE(CTXMD2, MD2, 16, 16)
+   ; hash' = MD2 . MD2.hash
+   };
+
 DEFINE_TYPE_AND_INSTANCES_SIMPLE(CTXMD4, MD4, 16, 64)
+   ; hash' = MD4 . MD4.hash
+   };
+
 DEFINE_TYPE_AND_INSTANCES_SIMPLE(CTXMD5, MD5, 16, 64)
+   ; hash' = MD5 . MD5.hash
+   };
 
 DEFINE_TYPE_AND_INSTANCES_SIMPLE(CTXSHA1, SHA1, 20, 64)
+   ; hash' = SHA1 . SHA1.hash
+   };
 
 DEFINE_TYPE_AND_INSTANCES_SIMPLE(CTXSHA224, SHA224, 28, 64)
+   ; hash' = SHA224 . SHA224.hash
+   };
+
 DEFINE_TYPE_AND_INSTANCES_SIMPLE(CTXSHA256, SHA256, 32, 64)
+   ; hash' = SHA256 . SHA256.hash
+   };
+
 DEFINE_TYPE_AND_INSTANCES_SIMPLE(CTXSHA384, SHA384, 48, 128)
+   ; hash' = SHA384 . SHA384.hash
+   };
+
 DEFINE_TYPE_AND_INSTANCES_SIMPLE(CTXSHA512, SHA512, 64, 128)
+   ; hash' = SHA512 . SHA512.hash
+   };
 
 DEFINE_TYPE_AND_INSTANCES_SIMPLE(CTXRIPEMD160, RIPEMD160, 20, 64)
+   ; hash' = RIPEMD160 . RIPEMD160.hash
+   };
+
 DEFINE_TYPE_AND_INSTANCES_SIMPLE(CTXTiger, Tiger, 24, 64)
+   ; hash' = Tiger . Tiger.hash
+   };
+
 DEFINE_TYPE_AND_INSTANCES_SIMPLE(CTXWhirlpool, Whirlpool, 64, 64)
+   ; hash' = Whirlpool . Whirlpool.hash
+   };
 
 DEFINE_TYPE_AND_INSTANCES_WITHLEN(CTXSkein256_256, Skein256_256, 256, Skein256, 32, 32)
+   ; hash' = Skein256_256 . Skein256.hash 32
+   };
+
 DEFINE_TYPE_AND_INSTANCES_WITHLEN(CTXSkein512_512, Skein512_512, 512, Skein512, 64, 64)
+   ; hash' = Skein512_512 . Skein512.hash 64
+   };
+


### PR DESCRIPTION
The preprocessor of clang fails on identifiers with apostrophe
characters in macros. This is a hack to
work around this issue.

This is supposed to resolve issue https://github.com/vincenthz/hs-cryptohash-cryptoapi/issues/3.
