### PR TITLE
Require Cabal-Version 1.8

### DIFF
--- a/cryptohash-cryptoapi.cabal
+++ b/cryptohash-cryptoapi.cabal
@@ -9,7 +9,7 @@ Maintainer:          Vincent Hanquez <vincent@snarc.org>
 Synopsis:            Crypto-api interfaces for cryptohash
 Category:            Cryptography
 Build-Type:          Simple
-Cabal-Version:       >=1.6
+Cabal-Version:       >=1.8
 Homepage:            https://github.com/vincenthz/hs-cryptohash-cryptoapi
 data-files:          README.md
 


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: cryptohash-cryptoapi.cabal:17:34: version operators used. To use                                                                                                                                                                                                          
version operators the package needs to specify at least 'cabal-version: >=                                                                                                                                                                                                         
1.8'.
```